### PR TITLE
implement history metadata in ms and uvfits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marlu"
-version = "0.6.1"
+version = "0.7.0"
 authors = [
     "Christopher H. Jordan <christopherjordan87@gmail.com>",
     "Dev Null <dev.null@curtin.edu.au>",

--- a/benches/bench_io.rs
+++ b/benches/bench_io.rs
@@ -83,7 +83,7 @@ fn bench_ms_init_mwax_half_1247842824(crt: &mut Criterion) {
                     Some(obs_ctx.array_pos),
                 );
                 ms_writer
-                    .initialize_mwa(&vis_ctx, &obs_ctx, &mwa_ctx, &vis_sel.coarse_chan_range)
+                    .initialize_mwa(&vis_ctx, &obs_ctx, &mwa_ctx, None, &vis_sel.coarse_chan_range)
                     .unwrap();
             })
         },
@@ -128,6 +128,7 @@ fn bench_uvfits_init_mwax_half_1247842824(crt: &mut Criterion) {
                     Some(obs_ctx.array_pos),
                     obs_ctx.phase_centre,
                     obs_ctx.name.as_deref(),
+                    None,
                 )
                 .unwrap();
                 u.close().unwrap();
@@ -205,7 +206,7 @@ fn bench_ms_write_mwax_part_1247842824(crt: &mut Criterion) {
                     Some(obs_ctx.array_pos),
                 );
                 ms_writer
-                    .initialize_mwa(&vis_ctx, &obs_ctx, &mwa_ctx, &vis_sel.coarse_chan_range)
+                    .initialize_mwa(&vis_ctx, &obs_ctx, &mwa_ctx, None, &vis_sel.coarse_chan_range)
                     .unwrap();
                 ms_writer
                     .write_vis_marlu(
@@ -264,6 +265,7 @@ fn bench_uvfits_write_mwax_part_1247842824(crt: &mut Criterion) {
                     Some(obs_ctx.array_pos),
                     obs_ctx.phase_centre,
                     obs_ctx.name.as_deref(),
+                    None,
                 )
                 .unwrap();
                 uvfits_writer

--- a/benches/bench_io.rs
+++ b/benches/bench_io.rs
@@ -83,7 +83,13 @@ fn bench_ms_init_mwax_half_1247842824(crt: &mut Criterion) {
                     Some(obs_ctx.array_pos),
                 );
                 ms_writer
-                    .initialize_mwa(&vis_ctx, &obs_ctx, &mwa_ctx, None, &vis_sel.coarse_chan_range)
+                    .initialize_mwa(
+                        &vis_ctx,
+                        &obs_ctx,
+                        &mwa_ctx,
+                        None,
+                        &vis_sel.coarse_chan_range,
+                    )
                     .unwrap();
             })
         },
@@ -206,7 +212,13 @@ fn bench_ms_write_mwax_part_1247842824(crt: &mut Criterion) {
                     Some(obs_ctx.array_pos),
                 );
                 ms_writer
-                    .initialize_mwa(&vis_ctx, &obs_ctx, &mwa_ctx, None, &vis_sel.coarse_chan_range)
+                    .initialize_mwa(
+                        &vis_ctx,
+                        &obs_ctx,
+                        &mwa_ctx,
+                        None,
+                        &vis_sel.coarse_chan_range,
+                    )
                     .unwrap();
                 ms_writer
                     .write_vis_marlu(

--- a/src/context.rs
+++ b/src/context.rs
@@ -117,6 +117,26 @@ impl ObsContext {
     }
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct History {
+    /// The application (and version) used to create the file
+    pub application: Option<String>,
+    /// The command line arguments used to create the file
+    pub cmd_line: Option<String>,
+    /// What the application did (human readable)
+    pub message: Option<String>,
+}
+
+impl History {
+    pub fn as_comment(&self) -> String {
+        [
+            self.application.as_ref().map(|s| format!("Created by {}", s)),
+            self.cmd_line.as_ref().map(|s| format!("CmdLine: {}", s)),
+            self.message.as_ref().map(|s| format!("Msg: {}", s)),
+        ].into_iter().flatten().collect::<Vec<String>>().join("\n")
+    }
+}
+
 /// An extension of [`ObsContext`] that for MWA-specific metadata that is not
 /// present in some file types like uvfits.
 pub struct MwaObsContext {

--- a/src/context.rs
+++ b/src/context.rs
@@ -117,6 +117,7 @@ impl ObsContext {
     }
 }
 
+/// A container for metadata about how a visibility file was created.
 #[derive(Debug, Clone, Default)]
 pub struct History<'a> {
     /// The application (and version) used to create the file

--- a/src/context.rs
+++ b/src/context.rs
@@ -118,22 +118,26 @@ impl ObsContext {
 }
 
 #[derive(Debug, Clone, Default)]
-pub struct History {
+pub struct History<'a> {
     /// The application (and version) used to create the file
-    pub application: Option<String>,
+    pub application: Option<&'a str>,
     /// The command line arguments used to create the file
-    pub cmd_line: Option<String>,
+    pub cmd_line: Option<&'a str>,
     /// What the application did (human readable)
-    pub message: Option<String>,
+    pub message: Option<&'a str>,
 }
 
-impl History {
+impl<'a> History<'a> {
     pub fn as_comment(&self) -> String {
         [
-            self.application.as_ref().map(|s| format!("Created by {}", s)),
-            self.cmd_line.as_ref().map(|s| format!("CmdLine: {}", s)),
-            self.message.as_ref().map(|s| format!("Msg: {}", s)),
-        ].into_iter().flatten().collect::<Vec<String>>().join("\n")
+            self.application.map(|s| format!("Created by {}", s)),
+            self.cmd_line.map(|s| format!("CmdLine: {}", s)),
+            self.message.map(|s| format!("Msg: {}", s)),
+        ]
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>()
+        .join("\n")
     }
 }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -128,7 +128,8 @@ pub struct History<'a> {
 }
 
 impl<'a> History<'a> {
-    pub fn as_comment(&self) -> String {
+    /// Format history as a series of uvfits COMMENTs
+    pub fn as_comments(&self) -> Vec<String> {
         [
             self.application.map(|s| format!("Created by {}", s)),
             self.cmd_line.map(|s| format!("CmdLine: {}", s)),
@@ -137,7 +138,6 @@ impl<'a> History<'a> {
         .into_iter()
         .flatten()
         .collect::<Vec<_>>()
-        .join("\n")
     }
 }
 

--- a/src/io/ms.rs
+++ b/src/io/ms.rs
@@ -7,7 +7,7 @@ use crate::{
     io::error::{IOError, MeasurementSetWriteError::MeasurementSetFull},
     ndarray::{array, Array2, Array3, ArrayView, ArrayView3, Axis},
     num_complex::Complex,
-    LatLngHeight, MwaObsContext, ObsContext, RADec, VisContext, XyzGeodetic,
+    LatLngHeight, MwaObsContext, ObsContext, RADec, VisContext, XyzGeodetic, History,
 };
 
 use std::path::{Path, PathBuf};
@@ -1148,6 +1148,7 @@ impl MeasurementSetWriter {
     /// `avg_freq` - the frequency averaging factor which determines the number of frequencies that
     ///     will be written
     #[cfg(feature = "mwalib")]
+    #[allow(clippy::too_many_arguments)]
     pub fn initialize_from_mwalib(
         &self,
         corr_ctx: &CorrelatorContext,
@@ -1156,6 +1157,7 @@ impl MeasurementSetWriter {
         baseline_idxs: &[usize],
         avg_time: usize,
         avg_freq: usize,
+        history: Option<History>,
     ) -> Result<(), MeasurementSetWriteError> {
         let vis_ctx = VisContext::from_mwalib(
             corr_ctx,
@@ -1172,7 +1174,7 @@ impl MeasurementSetWriter {
 
         let mwa_ctx = MwaObsContext::from_mwalib(&corr_ctx.metafits_context);
 
-        self.initialize_mwa(&vis_ctx, &obs_ctx, &mwa_ctx, coarse_chan_range)
+        self.initialize_mwa(&vis_ctx, &obs_ctx, &mwa_ctx, history, coarse_chan_range)
     }
 
     /// Initialize a measurement set, including the extended MWA tables from a [`VisContext`],
@@ -1185,6 +1187,7 @@ impl MeasurementSetWriter {
         vis_ctx: &VisContext,
         obs_ctx: &ObsContext,
         mwa_ctx: &MwaObsContext,
+        history: Option<History>,
         coarse_chan_range: &Range<usize>,
     ) -> Result<(), MeasurementSetWriteError> {
         let ObsContext {
@@ -1194,7 +1197,7 @@ impl MeasurementSetWriter {
             ..
         } = &obs_ctx;
 
-        self.initialize(vis_ctx, obs_ctx)?;
+        self.initialize(vis_ctx, obs_ctx, history)?;
 
         self.add_mwa_mods()?;
 
@@ -1315,6 +1318,7 @@ impl MeasurementSetWriter {
         &self,
         vis_ctx: &VisContext,
         obs_ctx: &ObsContext,
+        history: Option<History>,
     ) -> Result<(), MeasurementSetWriteError> {
         trace!("initialize");
 
@@ -1524,16 +1528,31 @@ impl MeasurementSetWriter {
             .as_millis() as f64
             / 1000.;
         // TODO: cmd_line, message, params
-        let cmd_line = "TODO";
-        let message = "TODO";
-        let params = "TODO";
+        let (cmd_line, application, message) = match history {
+            Some(history) => (
+                match history.cmd_line {
+                    Some(cmd_line) => cmd_line,
+                    None => "".into(),
+                },
+                match history.application {
+                    Some(application) => application,
+                    None => "".into(),
+                },
+                match history.message {
+                    Some(message) => message,
+                    None => "".into(),
+                },
+            ),
+            None => ("".into(), format!("{} {}", PKG_NAME, PKG_VERSION), "".into()),
+        };
+        let params = "";
         self.write_history_row(
             &mut hist_table,
             0,
             time,
-            cmd_line,
-            message,
-            &format!("{} {}", PKG_NAME, PKG_VERSION),
+            &cmd_line,
+            &message,
+            &application,
             params,
         )?;
 
@@ -3126,6 +3145,46 @@ mod tests {
         [-211.53, -211.53],
     ];
 
+    fn get_cotter_history() -> History {
+        History {
+            application: Some(String::from("Cotter MWA preprocessor")),
+            cmd_line: Some(String::from(
+                "cotter \"-m\" \"tests/data/1254670392_avg/1254670392.metafits\" \
+                \"-o\" \"tests/data/1254670392_avg/1254670392.cotter.none.ms\" \
+                \"-allowmissing\" \"-nostats\" \"-nogeom\" \"-noantennapruning\" \
+                \"-nosbgains\" \"-noflagautos\" \"-noflagdcchannels\" \"-nocablelength\" \
+                \"-edgewidth\" \"0\" \"-initflag\" \"0\" \"-endflag\" \"0\" \"-sbpassband\" \
+                \"tests/data/subband-passband-32ch-unitary.txt\" \"-nostats\" \
+                \"-flag-strategy\" \"/usr/share/aoflagger/strategies/mwa-default.lua\" \
+                \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox01_00.fits\" \
+                \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox02_00.fits\" \
+                \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox03_00.fits\" \
+                \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox04_00.fits\" \
+                \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox05_00.fits\" \
+                \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox06_00.fits\" \
+                \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox07_00.fits\" \
+                \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox08_00.fits\" \
+                \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox09_00.fits\" \
+                \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox10_00.fits\" \
+                \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox11_00.fits\" \
+                \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox12_00.fits\" \
+                \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox13_00.fits\" \
+                \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox14_00.fits\" \
+                \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox15_00.fits\" \
+                \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox16_00.fits\" \
+                \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox17_00.fits\" \
+                \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox18_00.fits\" \
+                \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox19_00.fits\" \
+                \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox20_00.fits\" \
+                \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox21_00.fits\" \
+                \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox22_00.fits\" \
+                \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox23_00.fits\" \
+                \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox24_00.fits\"\
+                ")),
+            message: Some(String::from("Preprocessed & AOFlagged")),
+        }
+    }
+
     /// Test data:
     /// ```python
     /// tb.open('tests/data/1254670392_avg/1254670392.cotter.none.trunc.ms/ANTENNA')
@@ -3647,7 +3706,31 @@ mod tests {
                 &mut hist_table,
                 0,
                 5149221788.625,
-                "cotter \"-m\" \"tests/data/1254670392_avg/1254670392.metafits\" \"-o\" \"tests/data/1254670392_avg/1254670392.cotter.none.ms\" \"-allowmissing\" \"-nostats\" \"-nogeom\" \"-noantennapruning\" \"-nosbgains\" \"-noflagautos\" \"-noflagdcchannels\" \"-nocablelength\" \"-edgewidth\" \"0\" \"-initflag\" \"0\" \"-endflag\" \"0\" \"-sbpassband\" \"tests/data/subband-passband-32ch-unitary.txt\" \"-nostats\" \"-flag-strategy\" \"/usr/share/aoflagger/strategies/mwa-default.lua\" \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox01_00.fits\" \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox02_00.fits\" \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox03_00.fits\" \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox04_00.fits\" \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox05_00.fits\" \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox06_00.fits\" \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox07_00.fits\" \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox08_00.fits\" \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox09_00.fits\" \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox10_00.fits\" \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox11_00.fits\" \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox12_00.fits\" \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox13_00.fits\" \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox14_00.fits\" \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox15_00.fits\" \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox16_00.fits\" \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox17_00.fits\" \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox18_00.fits\" \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox19_00.fits\" \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox20_00.fits\" \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox21_00.fits\" \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox22_00.fits\" \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox23_00.fits\" \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox24_00.fits\"",
+                "cotter \"-m\" \"tests/data/1254670392_avg/1254670392.metafits\" \
+                \"-o\" \"tests/data/1254670392_avg/1254670392.cotter.none.ms\" \"-allowmissing\" \"-nostats\" \"-nogeom\" \"-noantennapruning\" \"-nosbgains\" \"-noflagautos\" \"-noflagdcchannels\" \"-nocablelength\" \"-edgewidth\" \"0\" \"-initflag\" \"0\" \"-endflag\" \"0\" \"-sbpassband\" \"tests/data/subband-passband-32ch-unitary.txt\" \"-nostats\" \"-flag-strategy\" \"/usr/share/aoflagger/strategies/mwa-default.lua\" \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox01_00.fits\" \
+                \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox02_00.fits\" \
+                \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox03_00.fits\" \
+                \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox04_00.fits\" \
+                \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox05_00.fits\" \
+                \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox06_00.fits\" \
+                \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox07_00.fits\" \
+                \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox08_00.fits\" \
+                \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox09_00.fits\" \
+                \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox10_00.fits\" \
+                \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox11_00.fits\" \
+                \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox12_00.fits\" \
+                \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox13_00.fits\" \
+                \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox14_00.fits\" \
+                \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox15_00.fits\" \
+                \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox16_00.fits\" \
+                \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox17_00.fits\" \
+                \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox18_00.fits\" \
+                \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox19_00.fits\" \
+                \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox20_00.fits\" \
+                \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox21_00.fits\" \
+                \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox22_00.fits\" \
+                \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox23_00.fits\" \
+                \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox24_00.fits\"",
                 "Preprocessed & AOFlagged",
                 "Cotter MWA preprocessor",
                 "timeavg=1,freqavg=1,windowSize=4",
@@ -3847,6 +3930,7 @@ mod tests {
                 &vis_sel.baseline_idxs,
                 avg_time,
                 avg_freq,
+                Some(get_cotter_history()),
             )
             .unwrap();
 
@@ -3922,13 +4006,13 @@ mod tests {
                     "OBSERVATION_ID",
                     "ORIGIN",
                     "PRIORITY",
+                    "APPLICATION",
+                    "CLI_COMMAND",
+                    "MESSAGE",
                     // TODO:
                     // "APP_PARAMS",
-                    // "CLI_COMMAND",
-                    // "MESSAGE",
                     // WONTDO:
                     // "TIME", // this is wrong in Cotter.
-                    // "APPLICATION", // Different application so these will never match
                 ],
             ),
             (
@@ -4393,20 +4477,20 @@ mod tests {
         //         "APPLIED", "COMMAND", "INTERVAL", "LEVEL", "REASON", "SEVERITY", "TIME", "TYPE",
         //     ],
         // ),
-        // (
-        //     "HISTORY",
-        //     &[
-        //         "APP_PARAMS",
-        //         "CLI_COMMAND",
-        //         "APPLICATION",
-        //         "MESSAGE",
-        //         "OBJECT_ID",
-        //         "OBSERVATION_ID",
-        //         "ORIGIN",
-        //         "PRIORITY",
-        //         "TIME",
-        //     ],
-        // ),
+        (
+            "HISTORY",
+            &[
+                // "APP_PARAMS",
+                "CLI_COMMAND",
+                "APPLICATION",
+                "MESSAGE",
+                // "OBJECT_ID",
+                // "OBSERVATION_ID",
+                // "ORIGIN",
+                // "PRIORITY",
+                // "TIME",
+            ],
+        ),
         (
             "OBSERVATION",
             &[
@@ -4504,6 +4588,7 @@ mod tests {
                 &vis_sel.baseline_idxs,
                 avg_time,
                 avg_freq,
+                Some(get_cotter_history()),
             )
             .unwrap();
 
@@ -4570,6 +4655,39 @@ mod tests {
 
         let (avg_time, avg_freq) = (2, 2);
 
+        let mut history = get_cotter_history();
+        history.cmd_line = Some("cotter \"-m\" \"tests/data/1254670392_avg/1254670392.metafits\" \
+        \"-o\" \"tests/data/1254670392_avg/1254670392.cotter.none.avg_4s_80khz.ms\" \
+        \"-allowmissing\" \"-nostats\" \"-nogeom\" \"-noantennapruning\" \"-nosbgains\" \
+        \"-noflagautos\" \"-noflagdcchannels\" \"-nocablelength\" \"-edgewidth\" \"0\" \
+        \"-initflag\" \"0\" \"-endflag\" \"0\" \"-sbpassband\" \
+        \"tests/data/subband-passband-32ch-unitary.txt\" \"-nostats\" \"-flag-strategy\" \
+        \"/usr/share/aoflagger/strategies/mwa-default.lua\" \"-timeres\" \"4\" \"-freqres\" \"80\" \
+        \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox01_00.fits\" \
+        \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox02_00.fits\" \
+        \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox03_00.fits\" \
+        \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox04_00.fits\" \
+        \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox05_00.fits\" \
+        \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox06_00.fits\" \
+        \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox07_00.fits\" \
+        \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox08_00.fits\" \
+        \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox09_00.fits\" \
+        \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox10_00.fits\" \
+        \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox11_00.fits\" \
+        \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox12_00.fits\" \
+        \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox13_00.fits\" \
+        \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox14_00.fits\" \
+        \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox15_00.fits\" \
+        \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox16_00.fits\" \
+        \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox17_00.fits\" \
+        \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox18_00.fits\" \
+        \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox19_00.fits\" \
+        \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox20_00.fits\" \
+        \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox21_00.fits\" \
+        \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox22_00.fits\" \
+        \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox23_00.fits\" \
+        \"tests/data/1254670392_avg/1254670392_20191009153257_gpubox24_00.fits\"".into());
+
         ms_writer
             .initialize_from_mwalib(
                 &corr_ctx,
@@ -4578,6 +4696,7 @@ mod tests {
                 &vis_sel.baseline_idxs,
                 avg_time,
                 avg_freq,
+                Some(history),
             )
             .unwrap();
 
@@ -4656,6 +4775,7 @@ mod tests {
                 &vis_sel.baseline_idxs,
                 avg_time,
                 avg_freq,
+                Some(get_cotter_history()),
             )
             .unwrap();
 
@@ -4759,7 +4879,7 @@ mod tests {
 
         let mut ms_writer =
             MeasurementSetWriter::new(&table_path, obs_ctx.phase_centre, Some(obs_ctx.array_pos));
-        ms_writer.initialize(&vis_ctx, &obs_ctx).unwrap();
+        ms_writer.initialize(&vis_ctx, &obs_ctx, None).unwrap();
 
         let good_jones_array = vis_sel.allocate_jones(fine_chans_per_coarse).unwrap();
         let good_weight_array = vis_sel.allocate_weights(fine_chans_per_coarse).unwrap();
@@ -4859,7 +4979,7 @@ mod tests {
 
         let mut ms_writer =
             MeasurementSetWriter::new(&table_path, obs_ctx.phase_centre, Some(obs_ctx.array_pos));
-        ms_writer.initialize(&vis_ctx, &obs_ctx).unwrap();
+        ms_writer.initialize(&vis_ctx, &obs_ctx, None).unwrap();
 
         // Break things by making vis_sel and vis_ctx too big
         vis_ctx.num_sel_timesteps += 1;

--- a/src/io/ms.rs
+++ b/src/io/ms.rs
@@ -1527,7 +1527,6 @@ impl MeasurementSetWriter {
             .duration_since(SystemTime::UNIX_EPOCH)?
             .as_millis() as f64
             / 1000.;
-        // TODO: cmd_line, message, params
         let default_message = format!("{} {}", PKG_NAME, PKG_VERSION);
         let (cmd_line, application, message) = match history {
             Some(History {

--- a/src/io/uvfits.rs
+++ b/src/io/uvfits.rs
@@ -306,24 +306,26 @@ impl UvfitsWriter {
         fits_write_history(fptr, "AIPS WTSCAL =  1.0")?;
 
         // Add in version information
-        let comment: String = match history {
-            Some(history) => history.as_comment(),
-            None => format!(
-                "Created by {} v{}",
-                env!("CARGO_PKG_NAME"),
-                env!("CARGO_PKG_VERSION")
-            ),
-        };
-        fits_write_comment(fptr, &comment)?;
         let software = match history {
             Some(History {
                 application: Some(app),
                 ..
-            }) => app,
-            _ => env!("CARGO_PKG_NAME"),
+            }) => (*app).to_string(),
+            _ => format!("{} v{}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION")),
         };
 
-        fits_write_string(fptr, "SOFTWARE", software, None)?;
+        match history {
+            Some(history) => {
+                for comment in &history.as_comments() {
+                    fits_write_comment(fptr, comment)?;
+                }
+            }
+            None => {
+                fits_write_comment(fptr, &format!("Created by {software}",))?;
+            }
+        };
+
+        fits_write_string(fptr, "SOFTWARE", &software, None)?;
         fits_write_string(
             fptr,
             "GITLABEL",

--- a/src/io/uvfits.rs
+++ b/src/io/uvfits.rs
@@ -22,7 +22,7 @@ use crate::{
     ndarray::{ArrayView3, Axis},
     num_complex::Complex,
     precession::precess_time,
-    Jones, LatLngHeight, RADec, VisContext, XyzGeodetic, ENH, UVW,
+    Jones, LatLngHeight, RADec, VisContext, XyzGeodetic, ENH, UVW, History,
 };
 use indicatif::{ProgressDrawTarget, ProgressStyle};
 use itertools::{izip, Itertools};
@@ -192,6 +192,7 @@ impl UvfitsWriter {
         phase_centre: RADec,
         obs_name: Option<&str>,
         array_pos: LatLngHeight,
+        history: Option<History>,
     ) -> Result<UvfitsWriter, UvfitsWriteError> {
         let path = path.as_ref();
         // Delete any file that already exists.
@@ -305,16 +306,29 @@ impl UvfitsWriter {
         fits_write_history(fptr, "AIPS WTSCAL =  1.0")?;
 
         // Add in version information
-        fits_write_comment(
-            fptr,
-            &format!(
+        let comment: String = match history {
+            Some(ref history) => history.as_comment(),
+            None => format!(
                 "Created by {} v{}",
                 env!("CARGO_PKG_NAME"),
                 env!("CARGO_PKG_VERSION")
             ),
+        };
+        fits_write_comment(
+            fptr,
+            &comment,
         )?;
+        let software = match history {
+            Some(History { application: Some(app), .. }) => app,
+            _ => env!("CARGO_PKG_NAME").to_string(),
+        };
 
-        fits_write_string(fptr, "SOFTWARE", env!("CARGO_PKG_NAME"), None)?;
+        fits_write_string(
+            fptr,
+            "SOFTWARE",
+            &software,
+            None
+        )?;
         fits_write_string(
             fptr,
             "GITLABEL",
@@ -359,6 +373,7 @@ impl UvfitsWriter {
         phase_centre: Option<RADec>,
         avg_time: usize,
         avg_freq: usize,
+        history: Option<History>,
     ) -> Result<UvfitsWriter, UvfitsWriteError> {
         let phase_centre = phase_centre
             .unwrap_or_else(|| RADec::from_mwalib_phase_or_pointing(&corr_ctx.metafits_context));
@@ -378,7 +393,7 @@ impl UvfitsWriter {
             avg_freq,
         );
 
-        Self::from_marlu(path, &vis_ctx, array_pos, phase_centre, Some(&field_name))
+        Self::from_marlu(path, &vis_ctx, array_pos, phase_centre, Some(&field_name), history)
     }
 
     pub fn from_marlu<T: AsRef<Path>>(
@@ -387,6 +402,7 @@ impl UvfitsWriter {
         array_pos: Option<LatLngHeight>,
         phase_centre: RADec,
         obs_name: Option<&str>,
+        history: Option<History>,
     ) -> Result<UvfitsWriter, UvfitsWriteError> {
         let avg_freqs_hz: Vec<f64> = vis_ctx.avg_frequencies_hz();
         let avg_centre_chan = avg_freqs_hz.len() / 2;
@@ -416,6 +432,7 @@ impl UvfitsWriter {
             phase_centre,
             obs_name,
             array_pos,
+            history,
         )
     }
 
@@ -1165,6 +1182,7 @@ pub(super) enum FitsioOrCStringError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use mwalib::get_required_fits_key_long_string;
     use tempfile::NamedTempFile;
 
     use fitsio::{
@@ -1178,7 +1196,7 @@ mod tests {
         },
         mwalib::{
             _get_fits_col, _get_required_fits_key, _open_fits, _open_hdu, fits_open, fits_open_hdu,
-            get_fits_col, get_required_fits_key,
+            get_fits_col, get_required_fits_key, _get_required_fits_key_long_string
         },
         selection::VisSelection,
     };
@@ -1723,6 +1741,7 @@ mod tests {
             None,
             1,
             1,
+            None,
         )
         .unwrap();
         for _timestep_index in vis_sel.timestep_range.clone() {
@@ -1785,6 +1804,7 @@ mod tests {
             array_pos,
             RADec::from_mwalib_phase_or_pointing(&corr_ctx.metafits_context),
             Some(&corr_ctx.metafits_context.obs_name),
+            None,
         )
         .unwrap();
         for _timestep_index in 0..vis_ctx.num_sel_timesteps {
@@ -1839,6 +1859,7 @@ mod tests {
             RADec::new_degrees(0.0, 60.0),
             Some("test"),
             LatLngHeight::new_mwa(),
+            None,
         )
         .unwrap();
 
@@ -1913,6 +1934,7 @@ mod tests {
             None,
             1,
             1,
+            None,
         )
         .unwrap();
 
@@ -2007,6 +2029,7 @@ mod tests {
             None,
             avg_time,
             avg_freq,
+            None,
         )
         .unwrap();
 
@@ -2101,6 +2124,7 @@ mod tests {
             None,
             1,
             1,
+            None,
         )
         .unwrap();
 
@@ -2339,5 +2363,92 @@ mod tests {
         let birli_ant_freqid: i32 =
             get_required_fits_key!(&mut birli_fptr, &birli_ant_hdu, "FREQID").unwrap();
         assert_eq!(birli_ant_freqid, -1);
+    }
+
+    /// Tests for Comments
+    #[test]
+    fn comments() {
+        let corr_ctx = get_mwa_legacy_context();
+
+        let tmp_uvfits_file = NamedTempFile::new().unwrap();
+
+        let vis_ctx = VisContext::from_mwalib(
+            &corr_ctx,
+            &(0..1),
+            &(0..1),
+            &[0],
+            1,
+            1,
+        );
+
+        let array_pos = Some(LatLngHeight {
+            longitude_rad: COTTER_MWA_LONGITUDE_RADIANS,
+            latitude_rad: COTTER_MWA_LATITUDE_RADIANS,
+            height_metres: COTTER_MWA_HEIGHT_METRES,
+        });
+
+        let history = History {
+            application: Some("Cotter MWA preprocessor".to_string()),
+            cmd_line: Some(
+                "cotter \"-m\" \"tests/data/1196175296_mwa_ord/1196175296.cotter.me\
+                tafits\" \"-o\" \"tests/data/1196175296_mwa_ord/1196175296.uvfits\" \"-allowmi\
+                ssing\" \"-edgewidth\" \"0\" \"-endflag\" \"0\" \"-initflag\" \"0\" \"-noantennaprunin\
+                g\" \"-nocablelength\" \"-noflagautos\" \"-noflagdcchannels\" \"-nogeom\" \"-nosbg\
+                ains\" \"-sbpassband\" \"tests/data/subband-passband-2ch-unitary.txt\" \"-sbst\
+                art\" \"1\" \"-sbcount\" \"2\" \"-nostats\" \"-flag-strategy\" \"/usr/local/share/ao\
+                flagger/strategies/mwa-default.lua\" \"tests/data/1196175296_mwa_ord/11961\
+                75296_20171201145440_gpubox01_00.fits\" \"tests/data/1196175296_mwa_ord/11\
+                96175296_20171201145440_gpubox02_00.fits\" \"tests/data/1196175296_mwa_ord\
+                /1196175296_20171201145540_gpubox01_01.fits\" \"tests/data/1196175296_mwa_\
+                ord/1196175296_20171201145540_gpubox02_01.fits\"".to_string()
+            ),
+            message: None
+        };
+
+        let mut u = UvfitsWriter::from_marlu(
+            tmp_uvfits_file.path(),
+            &vis_ctx,
+            array_pos,
+            RADec::from_mwalib_phase_or_pointing(&corr_ctx.metafits_context),
+            Some(&corr_ctx.metafits_context.obs_name),
+            Some(history),
+        )
+        .unwrap();
+        for _timestep_index in 0..vis_ctx.num_sel_timesteps {
+            for (baseline_index, (tile1, tile2)) in
+                vis_ctx.sel_baselines.clone().into_iter().enumerate()
+            {
+                u.write_vis_row(
+                    UVW::default(),
+                    tile1,
+                    tile2,
+                    vis_ctx.start_timestamp,
+                    (baseline_index..baseline_index + vis_ctx.num_sel_chans)
+                        .into_iter()
+                        .map(|int| int as f32)
+                        .collect::<Vec<_>>()
+                        .as_slice(),
+                )
+                .unwrap();
+            }
+        }
+        u.write_ants_from_mwalib(&corr_ctx.metafits_context)
+            .unwrap();
+
+        let cotter_uvfits_path = Path::new("tests/data/1196175296_mwa_ord/1196175296.uvfits");
+
+        let mut birli_fptr = fits_open!(&tmp_uvfits_file.path()).unwrap();
+        let mut cotter_fptr = fits_open!(&cotter_uvfits_path).unwrap();
+
+        let birli_primary_hdu = fits_open_hdu!(&mut birli_fptr, 0).unwrap();
+        let cotter_primary_hdu = fits_open_hdu!(&mut cotter_fptr, 0).unwrap();
+
+        // TODO: this isn't actually reading the comment.
+        let birli_comment: String = get_required_fits_key_long_string!(&mut birli_fptr, &birli_primary_hdu, "COMMENT").unwrap();
+        let cotter_comment: String = get_required_fits_key_long_string!(&mut cotter_fptr, &cotter_primary_hdu, "COMMENT").unwrap();
+        dbg!(&birli_comment);
+        dbg!(&cotter_comment);
+
+        assert_eq!(birli_comment, cotter_comment);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@ pub mod io;
 pub mod cuda;
 
 // Re-exports.
-pub use context::{MwaObsContext, ObsContext, VisContext};
+pub use context::{MwaObsContext, ObsContext, VisContext, History};
 pub use jones::Jones;
 pub use pos::{
     azel::AzEl,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@ pub mod io;
 pub mod cuda;
 
 // Re-exports.
-pub use context::{MwaObsContext, ObsContext, VisContext, History};
+pub use context::{History, MwaObsContext, ObsContext, VisContext};
 pub use jones::Jones;
 pub use pos::{
     azel::AzEl,


### PR DESCRIPTION
implement an optional History struct in visibility io, which contains metadata about how a file was created to be stored in both measurement sets (HISTORY table) and uvfits (COMMENTS).
